### PR TITLE
Fix Survival Creative Flight (e.g mod ability)

### DIFF
--- a/src/main/java/com/minelittlepony/unicopia/entity/player/PlayerPhysics.java
+++ b/src/main/java/com/minelittlepony/unicopia/entity/player/PlayerPhysics.java
@@ -86,6 +86,7 @@ public class PlayerPhysics extends EntityPhysics<PlayerEntity> implements Tickab
 
     public boolean isFlyingEither = false;
     public boolean isFlyingSurvival = false;
+    public boolean unicopiaFlying = false;
 
     private boolean soundPlaying;
 
@@ -204,6 +205,8 @@ public class PlayerPhysics extends EntityPhysics<PlayerEntity> implements Tickab
 
     private FlightType recalculateFlightType() {
         DimensionType dimension = entity.getWorld().getDimension();
+        if (entity.getAbilities().allowFlying) return FlightType.NONE;
+
 
         if ((RegistryUtils.isIn(entity.getWorld(), dimension, RegistryKeys.DIMENSION_TYPE, UTags.DimensionTypes.HAS_NO_ATMOSPHERE)
                 || InteractionManager.getInstance().getSyncedConfig().dimensionsWithoutAtmosphere().contains(RegistryUtils.getId(entity.getWorld(), dimension, RegistryKeys.DIMENSION_TYPE).toString()))
@@ -275,6 +278,18 @@ public class PlayerPhysics extends EntityPhysics<PlayerEntity> implements Tickab
         FlightType type = recalculateFlightType();
 
         boolean typeChanged = type != lastFlightType;
+
+        // If in creative flight, don't process any of our flight logic
+        if (entity.getAbilities().allowFlying) {
+            if (typeChanged) {
+                boolean wasFlying = isFlyingEither;
+                cancelFlight(false);
+
+                entity.calculateDimensions();
+                entity.getAbilities().flying = wasFlying;
+            }
+            return;
+        }
 
         if (typeChanged && (lastFlightType.isArtifical() || type.isArtifical())) {
             pony.spawnParticles(ParticleTypes.CLOUD, 10);

--- a/src/main/java/com/minelittlepony/unicopia/mixin/gravity/MixinLivingEntity.java
+++ b/src/main/java/com/minelittlepony/unicopia/mixin/gravity/MixinLivingEntity.java
@@ -17,7 +17,7 @@ abstract class MixinLivingEntity extends Entity implements Equine.Container<Livi
     private MixinLivingEntity() { super(null, null); }
 
     @ModifyConstant(method = "travel(Lnet/minecraft/util/math/Vec3d;)V", constant = {
-            @Constant(doubleValue = 0.08D),
+//            @Constant(doubleValue = 0.08D),
             @Constant(doubleValue = 0.01D)
     })
     private double modifyGravity(double initial) {


### PR DESCRIPTION
I tend to have issues related to creative-mode flight enabled by mods like Mystical Agriculture. This was the simplest fix I could figure out but it disables Unicopia flight entirely if the player can creative fly. It's fine for me but I don't assume that's what you'd intend.

Also fixes the height collision bugs that occurs as well.
