### PR TITLE
Fix #597 by using generosity trait

### DIFF
--- a/src/main/java/com/minelittlepony/unicopia/ability/magic/spell/effect/AreaProtectionSpell.java
+++ b/src/main/java/com/minelittlepony/unicopia/ability/magic/spell/effect/AreaProtectionSpell.java
@@ -28,7 +28,7 @@ public class AreaProtectionSpell extends AbstractAreaEffectSpell {
             .with(Trait.STRENGTH, 30)
             .build();
 
-    private static final SpellAttribute<CastOn> CAST_ON = SpellAttribute.createEnumerated(SpellAttributeType.CAST_ON, Trait.FOCUS, focus -> focus > 0 ? CastOn.SELF : CastOn.LOCATION);
+    private static final SpellAttribute<CastOn> CAST_ON = SpellAttribute.createEnumerated(SpellAttributeType.CAST_ON, Trait.GENEROSITY, generosity -> generosity > 0 ? CastOn.LOCATION : CastOn.SELF);
 
     static final TooltipFactory TOOLTIP = TooltipFactory.of(CAST_ON, RANGE);
 


### PR DESCRIPTION
Uses the same generosity check as the normal Protection (shield) spell.

Does *not* address any of the other comments I had in that issue.



https://github.com/user-attachments/assets/03fea69b-8768-48b1-812f-3b67f31dd6f2



Feel free to close this if you don't actually want it to be generosity-controlled; I kinda just assumed it was supposed to be (as stated in the issue)